### PR TITLE
Potential fix for code scanning alert no. 2: Insecure randomness

### DIFF
--- a/feedback.js
+++ b/feedback.js
@@ -436,10 +436,34 @@
     } catch (e) { return false; }
   }
 
+  // Generate a cryptographically secure random string of the given length
+  function secureRandomString(length) {
+    const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz";
+    const alphabetLength = alphabet.length;
+    let result = "";
+    // Each byte from crypto.getRandomValues gives us a value 0-255.
+    // We map it into the alphabet range while avoiding modulo bias by discarding
+    // values that would make the distribution uneven.
+    const bytes = new Uint8Array(length * 2);
+    let i = 0;
+    while (result.length < length) {
+      window.crypto.getRandomValues(bytes);
+      while (i < bytes.length && result.length < length) {
+        const randomByte = bytes[i++];
+        // 36 * 7 = 252, so discard 252-255 to keep selection uniform
+        if (randomByte < alphabetLength * 7) {
+          result += alphabet.charAt(randomByte % alphabetLength);
+        }
+      }
+      i = 0;
+    }
+    return result;
+  }
+
   function getAnonId() {
     let id = localStorage.getItem(ANON_ID_KEY);
     if (!id) {
-      id = "anon-" + Math.random().toString(36).substring(2, 12);
+      id = "anon-" + secureRandomString(10);
       localStorage.setItem(ANON_ID_KEY, id);
     }
     return id;


### PR DESCRIPTION
Potential fix for [https://github.com/houselearning/houselearning.github.io/security/code-scanning/2](https://github.com/houselearning/houselearning.github.io/security/code-scanning/2)

To fix the problem, replace the use of `Math.random()` in `getAnonId()` with a cryptographically secure random generator available in the browser, such as `window.crypto.getRandomValues`. This preserves the behavior of generating a random-looking, 10‑character, base‑36-like suffix while making it unpredictable.

Best targeted fix without changing external behavior:

- Introduce a small helper function (within the same IIFE in `feedback.js`) that returns a secure random string of the desired length using `crypto.getRandomValues`.
- Update `getAnonId()` so it calls this helper instead of using `Math.random()`.
- Keep the `"anon-"` prefix and overall format so any existing data or expectations about the ID format still hold.
- No imports are needed; `window.crypto` is built in for modern browsers.

Concretely, in `feedback.js`:
- Above or inside the same scope as `getAnonId`, add a helper like `secureRandomString(length)` that uses `Uint8Array` filled by `crypto.getRandomValues` and maps bytes to characters from a safe alphabet (`0-9a-z`).
- Replace line 442 so that `id` is assigned as `"anon-" + secureRandomString(10)` instead of using `Math.random().toString(36)...`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
